### PR TITLE
Add initial benchmark and do some performance improvements

### DIFF
--- a/sirc-vm/Cargo.toml
+++ b/sirc-vm/Cargo.toml
@@ -12,3 +12,10 @@ members = [
     "sbrc-vm",
     "toolchain",
 ]
+
+[profile.release]
+lto = true
+
+[profile.bench]
+inherits = "release"
+debug = true

--- a/sirc-vm/sbrc-vm/benches/byte_sieve.rs
+++ b/sirc-vm/sbrc-vm/benches/byte_sieve.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, fs, path::PathBuf};
+use std::{cell::RefCell, fs, path::PathBuf, time::Duration};
 
 use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
 use device_ram::{new_ram_device_file_mapped, new_ram_device_standard};
@@ -50,9 +50,13 @@ fn setup_vm(program: &[u8], mapped_file_path: PathBuf) -> Vm {
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Originally from compiling the byte-sieve example with `make all`
-    let program = fs::read("../sbrc-vm/benches/byte-sieve.bin").unwrap();
+    let mut binary_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    binary_path.push("benches/byte-sieve.bin");
+    println!("program binary path: [{:?}]", binary_path);
+    let program = fs::read(binary_path).unwrap();
     let mut group = c.benchmark_group("byte-sieve");
     group.sampling_mode(SamplingMode::Flat);
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function("byte sieve", |b| {
         b.iter(|| {
             let mut program_scratch_file = tempfile::NamedTempFile::new().unwrap();

--- a/sirc-vm/sbrc-vm/benches/performance-notes.md
+++ b/sirc-vm/sbrc-vm/benches/performance-notes.md
@@ -3,7 +3,7 @@
 ## Speed Improvement Log
 
 1. Tried inlining common shared instruction decoding functions - no change
-2. Enable LTO - 30% improvement (makes sense due to how modular everything is)
+2. Enable LTO - 30% improvement (makes sense due to how modular everything is) - thin LTO doesn't work as well for some reason
 
 ## Observations
 

--- a/sirc-vm/sbrc-vm/benches/performance-notes.md
+++ b/sirc-vm/sbrc-vm/benches/performance-notes.md
@@ -7,6 +7,7 @@
 1. Tried inlining common shared instruction decoding functions - no change
 2. Enable LTO - 30% improvement (makes sense due to how modular everything is) - thin LTO doesn't work as well for some reason
 3. Tried rayon to parallelise the bus device processing (poll_all).- It had way too much overhead in a tight loop. The benchmark reported a +91897% time increase
+4. Tried changing phase in CpuPeripheral::poll to a simple integer and pass integers around instead of enum references. It didn't affect performance but made it less readable. The optimiser is good!
 
 Roughly 1.6220 ms -> 1.0487 ms = 35% speedup!
 

--- a/sirc-vm/sbrc-vm/benches/performance-notes.md
+++ b/sirc-vm/sbrc-vm/benches/performance-notes.md
@@ -2,8 +2,13 @@
 
 ## Speed Improvement Log
 
+### 29th May 2024
+
 1. Tried inlining common shared instruction decoding functions - no change
 2. Enable LTO - 30% improvement (makes sense due to how modular everything is) - thin LTO doesn't work as well for some reason
+3. Tried rayon to parallelise the bus device processing (poll_all).- It had way too much overhead in a tight loop. The benchmark reported a +91897% time increase
+
+Roughly 1.6220 ms -> 1.0487 ms = 35% speedup!
 
 ## Observations
 

--- a/sirc-vm/sbrc-vm/benches/performance-notes.md
+++ b/sirc-vm/sbrc-vm/benches/performance-notes.md
@@ -1,0 +1,36 @@
+# Performance Testing Notes
+
+## Speed Improvement Log
+
+1. Tried inlining common shared instruction decoding functions - no change
+2. Enable LTO - 30% improvement (makes sense due to how modular everything is)
+
+## Observations
+
+### Byte Sieve
+
+#### Instruments
+
+```
+cargo instruments --bench byte_sieve -t time --release -- --bench
+```
+
+- Only has two devices on the bus, the program ROM and the memory mapped scratch file
+- 53% of CPU time in the CPU simulation and 47% in the bus devices
+  - This would probably be more skewed in other examples with more devices
+- Finding it hard to track down where all the CPU time in the bus is going, once I expand the `poll_all` node, about half the time goes missing.
+- There is some missing time in the CPU code too. It kind of seems that it just does a lot of work. I think I might need a try a different profiler with a higher resolution.
+- After enabling LTO the profile changed a lot. It seems like a lot of functions that were hot paths like the instruction decode functions got inlined
+- 5% improvement in passing bus assertions in to the poll_all function instead of using a field on the struct to store it
+
+#### Flame graph
+
+- Doesn't seem to profile across crates, so it basically just tells me the CPU time is going to `poll` and `poll_all`
+
+#### samply
+
+```
+samply record --rate 1997 target/release/deps/byte_sieve-976bfd0ddf1734b5 --bench
+```
+
+- Responsive UI, actually maps to the code properly so you can see hot spots and has both call tree and flame graph. I think this is probably the winner although you have to run the actual benchmark binary, rather than go via cargo

--- a/sirc-vm/sbrc-vm/src/lib.rs
+++ b/sirc-vm/sbrc-vm/src/lib.rs
@@ -17,7 +17,10 @@ use std::{cell::RefCell, fs::File, io::Write, path::PathBuf};
 
 use log::{error, info};
 
-use peripheral_bus::{device::Device, BusPeripheral};
+use peripheral_bus::{
+    device::{BusAssertions, Device},
+    BusPeripheral,
+};
 use peripheral_clock::ClockPeripheral;
 use peripheral_cpu::CpuPeripheral;
 
@@ -39,10 +42,11 @@ pub fn run_vm(vm: &Vm, register_dump_file: Option<PathBuf>) {
     let mut bus_peripheral = vm.bus_peripheral.borrow_mut();
     let clock_peripheral = vm.clock_peripheral.borrow();
 
+    let mut bus_assertions = BusAssertions::default();
     // TODO: Profile and make this actually performant (currently is ,less than 1 fps in a tight loop)
     let execute = |_| {
-        let merged_assertions = bus_peripheral.poll_all();
-        !merged_assertions.exit_simulation
+        bus_assertions = bus_peripheral.poll_all(bus_assertions);
+        !bus_assertions.exit_simulation
     };
 
     clock_peripheral.start_loop(execute);


### PR DESCRIPTION
- The benchmark is simple at the moment, and there isn't much on the bus, but is a good starting point to identify performance improvements that are low hanging fruit
- `cargo bench` will start the benchmark. Run it once to generate a baseline and then run it after a change to see the performance change
- Enabling fat LTO was the biggest win, 30% improvement with doing nothing. It makes the build very slow but worth it for the release builds.