### PR TITLE
Only run checks for the projects that have been changed in a commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,9 +4,20 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-pushd sirc-vm
-cargo fmt --all
-cargo build --release
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --verbose
-popd
+function pre_commit_sirc_vm {
+    pushd sirc-vm
+    cargo fmt --all
+    cargo build --release
+    cargo clippy --all-targets --all-features -- -D warnings
+    cargo test --verbose
+    popd
+}
+
+CHANGED_FILES=$(git diff --cached --name-only)
+
+echo "$CHANGED_FILES"
+
+if echo "$CHANGED_FILES" | grep --quiet "^sirc-vm"
+then
+    pre_commit_sirc_vm
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,6 +13,15 @@ function pre_commit_sirc_vm {
     popd
 }
 
+function pre_commit_sirc_tiledit {
+    pushd sirc-tiledit/build
+    meson compile -v
+    meson test --print-errorlogs
+    ninja clang-tidy
+    ninja clang-format-check
+    popd
+}
+
 CHANGED_FILES=$(git diff --cached --name-only)
 
 echo "$CHANGED_FILES"
@@ -20,4 +29,9 @@ echo "$CHANGED_FILES"
 if echo "$CHANGED_FILES" | grep --quiet "^sirc-vm"
 then
     pre_commit_sirc_vm
+fi
+
+if echo "$CHANGED_FILES" | grep --quiet "^sirc-tiledit"
+then
+    pre_commit_sirc_tiledit
 fi

--- a/sirc-tiledit/.idea/misc.xml
+++ b/sirc-tiledit/.idea/misc.xml
@@ -16,6 +16,7 @@
         <option name="profiles">
           <MesonProfile>
             <option name="buildDir" value="build" />
+            <option name="mesonExecutable" value="$USER_HOME$/.asdf/installs/meson/1.4.1/bin/meson" />
             <option name="toolchainName" value="Default" />
           </MesonProfile>
         </option>

--- a/sirc-tiledit/.tool-versions
+++ b/sirc-tiledit/.tool-versions
@@ -1,2 +1,2 @@
-meson 1.4.1
-ninja 1.11.1
+meson 1.8.2
+ninja 1.13.1

--- a/sirc-tiledit/README.md
+++ b/sirc-tiledit/README.md
@@ -10,10 +10,16 @@ support clangd (although you wouldn't get the
 UI editor)
 
 ```
+# or ./setup-macos.sh if you want to use homebrew llvm
 $ meson setup build
+
 $ cd build
 $ meson compile
 $ meson test
+
+# You need to compile before these steps, otherwise the qt generated headers won't be there
+$ ninja clang-tidy
+$ ninja clang-format-check
 ```
 
 # Roadmap

--- a/sirc-tiledit/native-macos-llvm.ini
+++ b/sirc-tiledit/native-macos-llvm.ini
@@ -1,0 +1,17 @@
+# Used with 'setup-macos.sh' to force meson to use the homebrew version of llvm
+
+[binaries]
+c = '/opt/homebrew/opt/llvm/bin/clang'
+cpp = '/opt/homebrew/opt/llvm/bin/clang++'
+clang_tidy = '/opt/homebrew/opt/llvm/bin/clang-tidy'
+
+[built-in options]
+c_args = ['--sysroot=@SDK_PATH@']
+cpp_args = ['--sysroot=@SDK_PATH@']
+clang_tidy_args = ['-extra-arg=-isysroot@SDK_PATH@']
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'aarch64'
+cpu = 'native'
+endian = 'little'

--- a/sirc-tiledit/setup-macos.sh
+++ b/sirc-tiledit/setup-macos.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Sets up a meson build directory on MacOS that uses the llvm toolchain installed
+# by homebrew, instead of the xcode toolchain.
+# It might be useful if you're having issues with missing headers in clang-tidy
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+SDK_PATH=$(xcrun --show-sdk-path)
+CPU_FAMILY=$(uname -m | grep -q arm64 && echo 'aarch64' || echo 'x86_64')
+
+sed "s|@SDK_PATH@|$SDK_PATH|g" native-macos-llvm.ini |
+sed "s|cpu_family = .*|cpu_family = '$CPU_FAMILY'|" > /tmp/meson_macos.ini
+
+meson setup build --native-file=/tmp/meson_macos.ini "$@"

--- a/sirc-vm/toolchain/src/printers/data.rs
+++ b/sirc-vm/toolchain/src/printers/data.rs
@@ -37,7 +37,7 @@ pub fn print_data_token(data_token: &DataToken) -> String {
         DataType::SymbolRef(ref_token) => match ref_token.ref_type {
             RefType::FullAddress => print_ref_token(ref_token),
             _ => panic!(
-                "Only FullAddress reference type is valid for data tokens. Got [{:?}]",
+                "Only the FullAddress reference type is valid for data tokens. Got [{:?}]",
                 ref_token.ref_type
             ),
         },


### PR DESCRIPTION
- This should avoid the annoying problem with pre-commit hooks where the rust project needs to be built/tested even if you have only touched the c++ project
- To make this even better, it might be nice to check subsets of the projects, or only run tests for code that has changed, but that sounds complex